### PR TITLE
Fix string conversion methods

### DIFF
--- a/src/Entity/Exercice.php
+++ b/src/Entity/Exercice.php
@@ -215,8 +215,8 @@ class Exercice
         return $this;
     }
 
-    //ici je fais mon __tostring
-    public function __tostring()
+    //ici je fais mon __toString
+    public function __toString()
     {
         return $this->exerciceName;
 

--- a/src/Entity/MuscleGroup.php
+++ b/src/Entity/MuscleGroup.php
@@ -233,7 +233,7 @@ class MuscleGroup
         return $this;
     }
     
-    public function __tostring()
+    public function __toString()
     {
         return $this->muscleGroup;
     }

--- a/src/Entity/Performance.php
+++ b/src/Entity/Performance.php
@@ -71,17 +71,17 @@ class Performance
     
     public function getDateOfPerformance(): ?string
     {
-        return $this->dateOfPerformance->format('d.m.Y') ;
+        return $this->dateOfPerformance?->format('d.m.Y');
     }
-        
-    public function setDateOfPerformance($dateOfPerformance): static
+
+    public function setDateOfPerformance(\DateTimeInterface $dateOfPerformance): static
     {
         $this->dateOfPerformance = $dateOfPerformance;
-        
+
         return $this;
     }
         
-    public function __tostring()
+    public function __toString()
     {
         return $this->personnalRecord."kg : ".$this->exerciceMesured;
     }

--- a/src/Entity/Program.php
+++ b/src/Entity/Program.php
@@ -159,11 +159,10 @@ class Program
         return $this;
     }
 
-    public function __tostring()
+    public function __toString()
     {
-        return $this->title
+        return $this->title;
         // .' ('.$this->muscleGroupTargeted->getName().' - '.$this->secondaryMuscleGroupTargeted->getName().')'
-        ;
     }
 
 

--- a/src/Entity/Session.php
+++ b/src/Entity/Session.php
@@ -72,7 +72,7 @@ class Session
         return $this;
     }
     
-    public function __tostring()
+    public function __toString()
     {
         return $this->program.' - '.$this->dateSession->format('d.m.Y');
     }

--- a/src/Entity/Tracking.php
+++ b/src/Entity/Tracking.php
@@ -70,7 +70,7 @@ class Tracking
 
     public function getDateOfTracking(): ?string
     {
-        return $this->dateOfTracking->format('d.m.Y');
+        return $this->dateOfTracking?->format('d.m.Y');
     }
 
     public function setDateOfTracking(\DateTimeInterface $dateOfTracking): static

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -447,7 +447,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 
 
 
-    public function __tostring ()
+    public function __toString ()
     {
         return $this->username;
     }

--- a/src/Entity/WorkoutPlan.php
+++ b/src/Entity/WorkoutPlan.php
@@ -79,7 +79,7 @@ class WorkoutPlan
         return $this;
     }
 
-    public function __tostring()
+    public function __toString()
     {
         return $this->exercice;
     }

--- a/src/Service/EquivalentService.php
+++ b/src/Service/EquivalentService.php
@@ -166,8 +166,8 @@ class EquivalentService
         }
     }
 
-    public function __tostring()
+    public function __toString()
     {
-        return $this->getEquivalent();
+        return json_encode(self::getEquivalent(0));
     }
 }

--- a/tests/Entity/PerformanceTest.php
+++ b/tests/Entity/PerformanceTest.php
@@ -1,0 +1,33 @@
+<?php
+namespace App\Tests\Entity;
+
+use App\Entity\Performance;
+use App\Entity\Exercice;
+use PHPUnit\Framework\TestCase;
+
+class PerformanceTest extends TestCase
+{
+    public function testToStringReturnsRecordWithExercise()
+    {
+        $perf = new Performance();
+        $perf->setPersonnalRecord('100');
+        $ex = new Exercice();
+        $ex->setExerciceName('Bench');
+        $perf->setExerciceMesured($ex);
+        $this->assertSame('100kg : Bench', (string) $perf);
+    }
+
+    public function testGetDateOfPerformanceReturnsFormattedDate()
+    {
+        $perf = new Performance();
+        $date = new \DateTime('2024-05-21');
+        $perf->setDateOfPerformance($date);
+        $this->assertSame('21.05.2024', $perf->getDateOfPerformance());
+    }
+
+    public function testGetDateOfPerformanceReturnsNullWhenNoDate()
+    {
+        $perf = new Performance();
+        $this->assertNull($perf->getDateOfPerformance());
+    }
+}

--- a/tests/Entity/ProgramTest.php
+++ b/tests/Entity/ProgramTest.php
@@ -1,0 +1,15 @@
+<?php
+namespace App\Tests\Entity;
+
+use App\Entity\Program;
+use PHPUnit\Framework\TestCase;
+
+class ProgramTest extends TestCase
+{
+    public function testToStringReturnsTitle()
+    {
+        $program = new Program();
+        $program->setTitle('Leg Day');
+        $this->assertSame('Leg Day', (string) $program);
+    }
+}

--- a/tests/Entity/TrackingTest.php
+++ b/tests/Entity/TrackingTest.php
@@ -1,0 +1,23 @@
+<?php
+namespace App\Tests\Entity;
+
+use App\Entity\Tracking;
+use App\Entity\User;
+use PHPUnit\Framework\TestCase;
+
+class TrackingTest extends TestCase
+{
+    public function testGetDateOfTrackingReturnsFormattedDate()
+    {
+        $tracking = new Tracking();
+        $date = new \DateTime('2024-05-20');
+        $tracking->setDateOfTracking($date);
+        $this->assertSame('20.05.2024', $tracking->getDateOfTracking());
+    }
+
+    public function testGetDateOfTrackingReturnsNullWhenNoDate()
+    {
+        $tracking = new Tracking();
+        $this->assertNull($tracking->getDateOfTracking());
+    }
+}


### PR DESCRIPTION
## Summary
- fix `__toString()` implementations across entities
- guard against null dates in Tracking and Performance
- update EquivalentService
- add simple PHPUnit tests for Program, Tracking, and Performance

## Testing
- `phpunit -c phpunit.xml.dist --colors=never`

------
https://chatgpt.com/codex/tasks/task_e_68654a0c4c648321a36c7de66acc8556