### PR TITLE
Implement leaderboard

### DIFF
--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -626,7 +626,7 @@ class UserController extends AbstractController
 
     // this function deletes every program of the user
     #[Route('/user/deleteAllPrograms/{id}', name: 'app_user_deleteAllPrograms')]
-    public function deleteAllPrograms(Request $request, 
+    public function deleteAllPrograms(Request $request,
                             EntityManagerInterface $em,
                             User $user = null): Response
     {
@@ -645,6 +645,30 @@ class UserController extends AbstractController
         $em->flush();
 
         return $this->redirectToRoute('app_user');
+    }
+
+    #[Route('/leaderboard', name: 'app_user_leaderboard')]
+    public function leaderboard(UserRepository $ur): Response
+    {
+        if (!$this->getUser()) {
+            return $this->redirectToRoute('app_login');
+        }
+
+        $topUsers = $ur->findLeaderboard(10);
+        $allUsers = $ur->findLeaderboard();
+        $position = null;
+
+        foreach ($allUsers as $index => $user) {
+            if ($user === $this->getUser()) {
+                $position = $index + 1;
+                break;
+            }
+        }
+
+        return $this->render('user/leaderboard.html.twig', [
+            'users' => $topUsers,
+            'position' => $position,
+        ]);
     }
     
 }

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -38,6 +38,24 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
         $this->getEntityManager()->flush();
     }
 
+    /**
+     * Returns users ordered by score in descending order.
+     *
+     * @param int|null $limit Maximum number of results or null for all users.
+     * @return User[]
+     */
+    public function findLeaderboard(?int $limit = null): array
+    {
+        $qb = $this->createQueryBuilder('u')
+            ->orderBy('u.score', 'DESC');
+
+        if ($limit !== null) {
+            $qb->setMaxResults($limit);
+        }
+
+        return $qb->getQuery()->getResult();
+    }
+
     //    /**
     //     * @return User[] Returns an array of User objects
     //     */

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -59,6 +59,8 @@
                     class="w-full block py-2 text-2xl font-semibold px-6 min-[1280px]:text-lg  min-[1280px]:py-1 min-[1280px]:px-2 rounded-lg dark:hover:bg-quinary/40 light:hover:bg-senary/60">Exercises</a>
                 <a href="{{ path('app_ressource') }}"
                     class="w-full block py-2 text-2xl font-semibold px-6 min-[1280px]:text-lg  min-[1280px]:py-1 min-[1280px]:px-2 rounded-lg dark:hover:bg-quinary/40 light:hover:bg-senary/60">Resources</a>
+                <a href="{{ path('app_user_leaderboard') }}"
+                    class="w-full block py-2 text-2xl font-semibold px-6 min-[1280px]:text-lg  min-[1280px]:py-1 min-[1280px]:px-2 rounded-lg dark:hover:bg-quinary/40 light:hover:bg-senary/60">Leaderboard</a>
             </div>
             {% if is_granted('ROLE_ADMIN') %}
             <div

--- a/templates/user/leaderboard.html.twig
+++ b/templates/user/leaderboard.html.twig
@@ -1,0 +1,32 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Leaderboard{% endblock %}
+
+{% block body %}
+<div class="w-5/6 mx-auto my-8">
+    <div class="dark:bg-secondary/60 light:bg-secondary_light/60 rounded-lg p-9 backdrop-blur-md drop-shadow-xl">
+        <h1 class="text-2xl font-bold mb-6">Leaderboard</h1>
+        <table class="min-w-full text-left">
+            <thead>
+                <tr>
+                    <th class="px-4 py-2">Rank</th>
+                    <th class="px-4 py-2">User</th>
+                    <th class="px-4 py-2">Score</th>
+                </tr>
+            </thead>
+            <tbody>
+            {% for user in users %}
+                <tr class="{{ loop.index is odd ? 'dark:bg-secondary/40 light:bg-secondary_light/40' : 'dark:bg-tertiary/40 light:bg-tertiary_light/40' }}">
+                    <td class="px-4 py-2">{{ loop.index }}</td>
+                    <td class="px-4 py-2">{{ user.username }}</td>
+                    <td class="px-4 py-2">{{ user.score }}</td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+        {% if position %}
+        <p class="mt-4 font-medium">You are {{ position }}{% if position == 1 %}st{% elseif position == 2 %}nd{% elseif position == 3 %}rd{% else %}th{% endif %} on the leaderboard.</p>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add repository method to fetch leaderboard
- expose new `/leaderboard` route
- show player's rank and top users via Twig template
- link leaderboard in navigation

## Testing
- `phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686552f36c8483219e707c6b58a860de