### PR TITLE
Add intensification options

### DIFF
--- a/migrations/Version20240712000000.php
+++ b/migrations/Version20240712000000.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240712000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add intensificationMethod to workout_plan';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE workout_plan ADD intensification_method VARCHAR(20) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE workout_plan DROP intensification_method');
+    }
+}

--- a/src/Entity/WorkoutPlan.php
+++ b/src/Entity/WorkoutPlan.php
@@ -19,6 +19,9 @@ class WorkoutPlan
     #[ORM\Column]
     private ?int $weightsUsed = null;
 
+    #[ORM\Column(length: 20, nullable: true)]
+    private ?string $intensificationMethod = null;
+
     #[ORM\ManyToOne(inversedBy: 'workoutPlans')]
     #[ORM\JoinColumn(nullable: false)]
     private ?Exercice $exercice = null;
@@ -51,6 +54,18 @@ class WorkoutPlan
     public function setWeightsUsed(int $weightsUsed): static
     {
         $this->weightsUsed = $weightsUsed;
+
+        return $this;
+    }
+
+    public function getIntensificationMethod(): ?string
+    {
+        return $this->intensificationMethod;
+    }
+
+    public function setIntensificationMethod(?string $intensificationMethod): static
+    {
+        $this->intensificationMethod = $intensificationMethod;
 
         return $this;
     }

--- a/src/Form/WorkoutType.php
+++ b/src/Form/WorkoutType.php
@@ -11,6 +11,7 @@ use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Doctrine\Common\Collections\Collection;
 
 class WorkoutType extends AbstractType
@@ -36,6 +37,20 @@ class WorkoutType extends AbstractType
             'attr' => [
                 'placeholder' => 'Weights used',
                 'class' => 'dark:text-white light:text-black dark:bg-primary/80 light:bg-primary_light/80 border dark:border-primary light:border-primary_light w-full px-4 py-2 rounded-lg focus:outline-none focus:ring-2 dark:focus:ring-blue-600 light:focus:ring-white mb-8'
+            ],
+            'row_attr' => ['class' => 'flex flex-col w-full'],
+        ])
+        ->add('intensificationMethod', ChoiceType::class, [
+            'label' => 'Intensification',
+            'required' => false,
+            'choices' => [
+                'None' => null,
+                'Drop set' => 'drop_set',
+                'Bi-set' => 'bi_set',
+                'Super set' => 'super_set',
+            ],
+            'attr' => [
+                'class' => 'dark:text-white light:text-black dark:bg-primary/80 light:bg-primary_light/80 border dark:border-primary light:border-primary_light w-full px-4 py-2 rounded-lg focus:outline-none focus:ring-2 dark:focus:ring-blue-600 light:focus:ring-white mb-8',
             ],
             'row_attr' => ['class' => 'flex flex-col w-full'],
         ])

--- a/templates/training/new.html.twig
+++ b/templates/training/new.html.twig
@@ -67,6 +67,12 @@
                                 <span>
                                     <a href="{{ path('app_exercice_details', {'id': workout.exercice.id}) }}" class="dark:text-quinary light:text-black light:bg-quinary light:px-2 hover:underline">{{ workout.exercice.exerciceName }}</a> 
                                     : {{ workout.numberOfRepetitions }} reps of {{ workout.weightsUsed }}kgs
+                                    {% if workout.intensificationMethod %}
+                                        ({{ workout.intensificationMethod|replace({'drop_set':'Drop set','bi_set':'Bi-set','super_set':'Super set'}) }})
+                                    {% endif %}
+                                    {% if workout.intensificationMethod %}
+                                        ({{ workout.intensificationMethod|replace({'drop_set':'Drop set','bi_set':'Bi-set','super_set':'Super set'}) }})
+                                    {% endif %}
                                 </span>
                                 <a href="{{ path('removeWP_Program', {'program': program.id, 'workoutPlan': workout.id}) }}" class="text-red-500 hover:scale-110 duration-100"><i class="fa-regular fa-square-minus"></i></a>
                             </p>

--- a/tests/Entity/WorkoutPlanTest.php
+++ b/tests/Entity/WorkoutPlanTest.php
@@ -1,0 +1,15 @@
+<?php
+namespace App\Tests\Entity;
+
+use App\Entity\WorkoutPlan;
+use PHPUnit\Framework\TestCase;
+
+class WorkoutPlanTest extends TestCase
+{
+    public function testGetAndSetIntensificationMethod()
+    {
+        $wp = new WorkoutPlan();
+        $wp->setIntensificationMethod('drop_set');
+        $this->assertSame('drop_set', $wp->getIntensificationMethod());
+    }
+}


### PR DESCRIPTION
## Summary
- allow specifying intensification type on workout plans
- expose intensification options in the workout form
- show the chosen intensification in the program view
- database migration for the new field
- test WorkoutPlan's intensification field

## Testing
- `./bin/phpunit` *(fails: `/usr/bin/env: ‘php’: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_686ccd1661808321bdc288081aab762c