### PR TITLE
Make API Platform backend runnable

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,5 @@
+APP_ENV=dev
+APP_SECRET=ChangeMeSecret
+DATABASE_URL="mysql://app:app@127.0.0.1:3306/musclemind?serverVersion=8.0"
+JWT_PASSPHRASE="change_this_passphrase"
+CORS_ALLOW_ORIGIN="http://localhost:5173"

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,10 @@
+/vendor/
+/var/*
+!/var/
+!/var/.gitignore
+/.env.local
+/.env.*.local
+/public/bundles/
+/node_modules/
+.DS_Store
+phpunit.xml

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,55 @@
+# MuscleMind API Platform Backend
+
+Ce dossier contient un squelette Symfony 7 + API Platform 3 prêt à être branché à une base de données MySQL et sécurisé par JWT.
+
+## Installation
+
+```bash
+cd backend
+cp .env.example .env # (ou personnalisez directement .env)
+composer install
+php bin/console doctrine:database:create --if-not-exists
+php bin/console doctrine:migrations:migrate
+php bin/console lexik:jwt:generate-keypair --overwrite --no-interaction
+symfony server:start -d --dir=public
+```
+
+## Points clés
+
+- **API Platform** expose automatiquement les entités `User`, `TrainingProgram`, `TrainingSession` en REST et GraphQL.
+- **Groupes de sérialisation** (`user:read`, `program:write`, etc.) contrôlent précisément les champs exposés.
+- **JWT** via LexikJWTAuthenticationBundle protège toutes les routes sauf `/auth/login`.
+- **Filtres** (recherche, dates) et **pagination** sont activés.
+- **Swagger UI** et **GraphiQL** sont livrés par API Platform.
+- **Console Symfony** (`bin/console`) et point d'entrée HTTP (`public/index.php`) sont déjà prêts, ce qui permet de lancer des commandes standard (`cache:clear`, `messenger:consume`, etc.).
+
+## Tests
+
+```bash
+php bin/phpunit
+```
+
+Le test d'exemple `ProgramApiTest` vérifie la pagination et le schéma JSON-LD retourné.
+
+> Le bootstrap PHPUnit prépare un schéma SQLite éphémère grâce à Doctrine `SchemaTool`. Aucun serveur MySQL n'est nécessaire pour les tests.
+
+## Structure
+
+```
+backend/
+├── bin/                # console Symfony
+├── config/             # configuration Framework/API Platform/JWT
+├── public/             # front-controller HTTP
+├── src/Entity          # entités Doctrine exposées via API Platform
+├── tests/              # ApiTestCase + bootstrap Dotenv
+├── translations/       # i18n (vide par défaut)
+└── var/                # caches et logs ignorés par git
+```
+
+## Ajouter une ressource
+
+1. Créer l'entité Doctrine dans `src/Entity`.
+2. L'annoter avec `#[ApiResource]` en définissant les opérations et groupes.
+3. Générer la migration (`php bin/console make:migration`).
+4. Implémenter la politique de sécurité (`security.yaml`).
+5. Tester via PHPUnit et via la console API Platform (`/docs`).

--- a/backend/bin/console
+++ b/backend/bin/console
@@ -1,0 +1,21 @@
+#!/usr/bin/env php
+<?php
+
+use App\Kernel;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+
+if (!is_dir(dirname(__DIR__).'/vendor')) {
+    throw new LogicException('Dependencies are missing. Run "composer install" inside backend/.');
+}
+
+if (!is_file(dirname(__DIR__).'/vendor/autoload_runtime.php')) {
+    throw new LogicException('Symfony Runtime is missing. Run "composer require symfony/runtime".');
+}
+
+require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
+
+return function (array $context) {
+    $kernel = new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);
+
+    return new Application($kernel);
+};

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -1,0 +1,54 @@
+{
+  "name": "musclemind/api-platform-backend",
+  "description": "Skeleton API Platform backend for MuscleMind",
+  "type": "project",
+  "require": {
+    "php": "^8.2",
+    "ext-ctype": "*",
+    "ext-iconv": "*",
+    "symfony/framework-bundle": "^7.1",
+    "symfony/runtime": "^7.1",
+    "symfony/dotenv": "^7.1",
+    "symfony/orm-pack": "^2.3",
+    "symfony/security-bundle": "^7.1",
+    "symfony/serializer-pack": "^1.0",
+    "symfony/validator": "^7.1",
+    "symfony/monolog-bundle": "^3.8",
+    "symfony/twig-bundle": "^7.1",
+    "api-platform/core": "^3.3",
+    "lexik/jwt-authentication-bundle": "^3.4",
+    "nelmio/cors-bundle": "^3.2",
+    "twig/twig": "^3.10"
+  },
+  "require-dev": {
+    "symfony/maker-bundle": "^1.57",
+    "symfony/debug-bundle": "^7.1",
+    "symfony/web-profiler-bundle": "^7.1",
+    "symfony/test-pack": "^1.0",
+    "phpunit/phpunit": "^10.5"
+  },
+  "autoload": {
+    "psr-4": {
+      "App\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "App\\Tests\\": "tests/"
+    }
+  },
+  "scripts": {
+    "auto-scripts": {
+      "cache:clear": "symfony-cmd",
+      "assets:install %PUBLIC_DIR%": "symfony-cmd"
+    },
+    "post-install-cmd": [
+      "@auto-scripts"
+    ],
+    "post-update-cmd": [
+      "@auto-scripts"
+    ]
+  },
+  "minimum-stability": "stable",
+  "prefer-stable": true
+}

--- a/backend/config/bootstrap.php
+++ b/backend/config/bootstrap.php
@@ -1,0 +1,14 @@
+<?php
+
+use Symfony\Component\Dotenv\Dotenv;
+
+require dirname(__DIR__).'/vendor/autoload.php';
+
+if (is_array($env = @include dirname(__DIR__).'/.env.local.php')) {
+    $_SERVER += $env;
+    $_ENV += $env;
+} elseif (!class_exists(Dotenv::class)) {
+    throw new LogicException('Symfony Dotenv is not installed. Try running "composer require symfony/dotenv".');
+} else {
+    (new Dotenv())->usePutenv(false)->bootEnv(dirname(__DIR__).'/.env');
+}

--- a/backend/config/bundles.php
+++ b/backend/config/bundles.php
@@ -1,0 +1,16 @@
+<?php
+
+return [
+    Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
+    Symfony\Bundle\TwigBundle\TwigBundle::class => ['all' => true],
+    Doctrine\Bundle\DoctrineBundle\DoctrineBundle::class => ['all' => true],
+    Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle::class => ['all' => true],
+    Symfony\Bundle\SecurityBundle\SecurityBundle::class => ['all' => true],
+    Symfony\Bundle\MonologBundle\MonologBundle::class => ['all' => true],
+    ApiPlatform\Symfony\Bundle\ApiPlatformBundle::class => ['all' => true],
+    Lexik\Bundle\JWTAuthenticationBundle\LexikJWTAuthenticationBundle::class => ['all' => true],
+    Nelmio\CorsBundle\NelmioCorsBundle::class => ['all' => true],
+    Symfony\Bundle\MakerBundle\MakerBundle::class => ['dev' => true],
+    Symfony\Bundle\DebugBundle\DebugBundle::class => ['dev' => true],
+    Symfony\Bundle\WebProfilerBundle\WebProfilerBundle::class => ['dev' => true, 'test' => true],
+];

--- a/backend/config/packages/api_platform.yaml
+++ b/backend/config/packages/api_platform.yaml
@@ -1,0 +1,29 @@
+api_platform:
+  title: 'MuscleMind API'
+  description: 'REST and GraphQL endpoints for programs and sessions.'
+  show_webby: false
+  formats:
+    jsonld: [ 'application/ld+json' ]
+    json: [ 'application/json' ]
+    html: [ 'text/html' ]
+  graphql:
+    enabled: true
+  defaults:
+    pagination_items_per_page: 10
+    pagination_client_enabled: true
+    pagination_client_items_per_page: true
+    pagination_maximum_items_per_page: 50
+    normalization_context:
+      groups: ['read:collection']
+    denormalization_context:
+      groups: ['write:collection']
+  swagger:
+    versions: [3]
+    api_keys:
+      JWT:
+        name: Authorization
+        type: header
+  mapping:
+    paths: ['%kernel.project_dir%/src/Entity']
+  patch_formats:
+    json: [ 'application/merge-patch+json' ]

--- a/backend/config/packages/dev/framework.yaml
+++ b/backend/config/packages/dev/framework.yaml
@@ -1,0 +1,5 @@
+when@dev:
+    framework:
+        profiler:
+            only_exceptions: false
+            collect_serializer_data: true

--- a/backend/config/packages/doctrine.yaml
+++ b/backend/config/packages/doctrine.yaml
@@ -1,0 +1,16 @@
+doctrine:
+    dbal:
+        url: '%env(resolve:DATABASE_URL)%'
+        charset: utf8mb4
+        server_version: '8.0'
+    orm:
+        auto_generate_proxy_classes: true
+        enable_lazy_ghost_objects: true
+        naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware
+        mappings:
+            App:
+                is_bundle: false
+                type: attribute
+                dir: '%kernel.project_dir%/src/Entity'
+                prefix: 'App\\Entity'
+                alias: App

--- a/backend/config/packages/doctrine_migrations.yaml
+++ b/backend/config/packages/doctrine_migrations.yaml
@@ -1,0 +1,4 @@
+doctrine_migrations:
+    migrations_paths:
+        'DoctrineMigrations': '%kernel.project_dir%/migrations'
+    enable_profiler: true

--- a/backend/config/packages/framework.yaml
+++ b/backend/config/packages/framework.yaml
@@ -1,0 +1,16 @@
+framework:
+    secret: '%env(APP_SECRET)%'
+    handle_all_throwables: true
+    http_method_override: false
+    session:
+        handler_id: null
+        cookie_secure: auto
+        cookie_samesite: lax
+    php_errors:
+        log: true
+    serializer: ~
+    validation: { enable_annotations: true }
+    translator:
+        default_path: '%kernel.project_dir%/translations'
+    router:
+        utf8: true

--- a/backend/config/packages/lexik_jwt_authentication.yaml
+++ b/backend/config/packages/lexik_jwt_authentication.yaml
@@ -1,0 +1,5 @@
+lexik_jwt_authentication:
+  secret_key: '%kernel.project_dir%/config/jwt/private.pem'
+  public_key: '%kernel.project_dir%/config/jwt/public.pem'
+  pass_phrase: '%env(resolve:JWT_PASSPHRASE)%'
+  token_ttl: 3600

--- a/backend/config/packages/monolog.yaml
+++ b/backend/config/packages/monolog.yaml
@@ -1,0 +1,9 @@
+monolog:
+    handlers:
+        main:
+            type: stream
+            path: '%kernel.logs_dir%/%kernel.environment%.log'
+            level: debug
+        console:
+            type: console
+            process_psr_3_messages: false

--- a/backend/config/packages/nelmio_cors.yaml
+++ b/backend/config/packages/nelmio_cors.yaml
@@ -1,0 +1,9 @@
+nelmio_cors:
+    defaults:
+        allow_origin: ['%env(CORS_ALLOW_ORIGIN)%']
+        allow_methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS']
+        allow_headers: ['Content-Type', 'Authorization']
+        expose_headers: ['Link', 'Content-Range']
+        max_age: 3600
+    paths:
+        '^/': ~

--- a/backend/config/packages/security.yaml
+++ b/backend/config/packages/security.yaml
@@ -1,0 +1,30 @@
+security:
+  password_hashers:
+    App\Entity\User:
+      algorithm: auto
+  providers:
+    app_user_provider:
+      entity:
+        class: App\Entity\User
+        property: email
+  firewalls:
+    dev:
+      pattern: ^/(_(profiler|wdt)|css|images|js)/
+      security: false
+    login:
+      pattern: ^/auth
+      stateless: true
+      json_login:
+        check_path: /auth/login
+        username_path: email
+        password_path: password
+        success_handler: lexik_jwt_authentication.handler.authentication_success
+        failure_handler: lexik_jwt_authentication.handler.authentication_failure
+    api:
+      pattern: ^/
+      stateless: true
+      jwt: ~
+  access_control:
+    - { path: ^/auth/login, roles: PUBLIC_ACCESS }
+    - { path: ^/users, roles: ROLE_ADMIN }
+    - { path: ^/, roles: IS_AUTHENTICATED_FULLY }

--- a/backend/config/packages/test/doctrine.yaml
+++ b/backend/config/packages/test/doctrine.yaml
@@ -1,0 +1,4 @@
+when@test:
+    doctrine:
+        dbal:
+            url: '%env(resolve:TEST_DATABASE_URL)%'

--- a/backend/config/packages/test/framework.yaml
+++ b/backend/config/packages/test/framework.yaml
@@ -1,0 +1,5 @@
+when@test:
+    framework:
+        test: true
+        session:
+            storage_factory_id: session.storage.factory.mock_file

--- a/backend/config/packages/twig.yaml
+++ b/backend/config/packages/twig.yaml
@@ -1,0 +1,3 @@
+twig:
+    default_path: '%kernel.project_dir%/templates'
+    strict_variables: false

--- a/backend/config/routes.yaml
+++ b/backend/config/routes.yaml
@@ -1,0 +1,7 @@
+controllers:
+    resource: '../src/Controller/'
+    type: attribute
+
+kernel:
+    resource: '../src/Kernel.php'
+    type: attribute

--- a/backend/config/routes/api_platform.yaml
+++ b/backend/config/routes/api_platform.yaml
@@ -1,0 +1,3 @@
+api_platform:
+    resource: '.'
+    type: api_platform

--- a/backend/config/routes/dev/web_profiler.yaml
+++ b/backend/config/routes/dev/web_profiler.yaml
@@ -1,0 +1,8 @@
+when@dev:
+    web_profiler_wdt:
+        resource: '@WebProfilerBundle/Resources/config/routing/wdt.xml'
+        prefix: /_wdt
+
+    web_profiler_profiler:
+        resource: '@WebProfilerBundle/Resources/config/routing/profiler.xml'
+        prefix: /_profiler

--- a/backend/config/services.yaml
+++ b/backend/config/services.yaml
@@ -1,0 +1,18 @@
+parameters: {  }
+
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+
+    App\:
+        resource: '../src/'
+        exclude:
+            - '../src/Kernel.php'
+            - '../src/Entity/'
+
+when@test:
+    services:
+        test.client.parameters:
+            http_client_options:
+                base_uri: 'http://localhost'

--- a/backend/phpunit.xml.dist
+++ b/backend/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         colors="true"
+         bootstrap="tests/bootstrap.php"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+>
+    <testsuites>
+        <testsuite name="Application Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <php>
+        <env name="APP_ENV" value="test"/>
+        <env name="APP_DEBUG" value="1"/>
+        <env name="TEST_DATABASE_URL" value="sqlite:///%kernel.project_dir%/var/app_test.db"/>
+    </php>
+</phpunit>

--- a/backend/public/index.php
+++ b/backend/public/index.php
@@ -1,0 +1,9 @@
+<?php
+
+use App\Kernel;
+
+require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
+
+return function (array $context) {
+    return new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);
+};

--- a/backend/src/Entity/TrainingProgram.php
+++ b/backend/src/Entity/TrainingProgram.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace App\Entity;
+
+use ApiPlatform\Metadata\ApiFilter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ORM\Entity]
+#[ApiResource(
+    operations: [
+        new Get(),
+        new GetCollection(),
+        new Post(security: "is_granted('ROLE_COACH')"),
+        new Patch(security: "object.getOwner() == user"),
+        new Delete(security: "is_granted('ROLE_ADMIN') or object.getOwner() == user")
+    ],
+    normalizationContext: ['groups' => ['program:read']],
+    denormalizationContext: ['groups' => ['program:write']]
+)]
+#[ApiFilter(SearchFilter::class, properties: ['name' => 'partial', 'owner.email' => 'exact'])]
+class TrainingProgram
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    #[Groups(['program:read'])]
+    private ?int $id = null;
+
+    #[ORM\Column(type: 'string', length: 255)]
+    #[Assert\NotBlank]
+    #[Groups(['program:read', 'program:write', 'session:read'])]
+    private string $name = '';
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    #[Groups(['program:read', 'program:write'])]
+    private ?string $description = null;
+
+    #[ORM\ManyToOne(targetEntity: User::class, inversedBy: 'programs')]
+    #[ORM\JoinColumn(nullable: false)]
+    #[Groups(['program:read'])]
+    private ?User $owner = null;
+
+    #[ORM\OneToMany(mappedBy: 'program', targetEntity: TrainingSession::class, cascade: ['persist'], orphanRemoval: true)]
+    #[Groups(['program:read'])]
+    private Collection $sessions;
+
+    #[ORM\Column(type: 'boolean')]
+    #[Groups(['program:read', 'program:write'])]
+    private bool $isPublished = false;
+
+    public function __construct()
+    {
+        $this->sessions = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(?string $description): self
+    {
+        $this->description = $description;
+        return $this;
+    }
+
+    public function getOwner(): ?User
+    {
+        return $this->owner;
+    }
+
+    public function setOwner(?User $owner): self
+    {
+        $this->owner = $owner;
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, TrainingSession>
+     */
+    public function getSessions(): Collection
+    {
+        return $this->sessions;
+    }
+
+    public function addSession(TrainingSession $session): self
+    {
+        if (!$this->sessions->contains($session)) {
+            $this->sessions[] = $session;
+            $session->setProgram($this);
+        }
+
+        return $this;
+    }
+
+    public function removeSession(TrainingSession $session): self
+    {
+        if ($this->sessions->removeElement($session) && $session->getProgram() === $this) {
+            $session->setProgram(null);
+        }
+
+        return $this;
+    }
+
+    public function isPublished(): bool
+    {
+        return $this->isPublished;
+    }
+
+    public function setIsPublished(bool $published): self
+    {
+        $this->isPublished = $published;
+        return $this;
+    }
+}

--- a/backend/src/Entity/TrainingSession.php
+++ b/backend/src/Entity/TrainingSession.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace App\Entity;
+
+use ApiPlatform\Metadata\ApiFilter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Doctrine\Orm\Filter\DateFilter;
+use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ORM\Entity]
+#[ApiResource(
+    operations: [
+        new Get(),
+        new GetCollection(),
+        new Post(securityPostDenormalize: "object.getProgram().getOwner() == user"),
+        new Patch(security: "object.getProgram().getOwner() == user"),
+        new Delete(security: "is_granted('ROLE_ADMIN') or object.getProgram().getOwner() == user")
+    ],
+    normalizationContext: ['groups' => ['session:read']],
+    denormalizationContext: ['groups' => ['session:write']]
+)]
+#[ApiFilter(DateFilter::class, properties: ['scheduledAt'])]
+#[ApiFilter(SearchFilter::class, properties: ['program.name' => 'partial'])]
+class TrainingSession
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    #[Groups(['session:read', 'program:read'])]
+    private ?int $id = null;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    #[Assert\NotNull]
+    #[Groups(['session:read', 'session:write', 'program:read'])]
+    private ?\DateTimeImmutable $scheduledAt = null;
+
+    #[ORM\Column(type: 'integer')]
+    #[Assert\Positive]
+    #[Groups(['session:read', 'session:write', 'program:read'])]
+    private int $durationMinutes = 60;
+
+    #[ORM\Column(type: 'json')]
+    #[Groups(['session:read', 'session:write'])]
+    private array $exercises = [];
+
+    #[ORM\ManyToOne(targetEntity: TrainingProgram::class, inversedBy: 'sessions')]
+    #[ORM\JoinColumn(nullable: false)]
+    #[Groups(['session:read', 'session:write'])]
+    private ?TrainingProgram $program = null;
+
+    #[ORM\Column(type: 'string', length: 50)]
+    #[Groups(['session:read', 'session:write'])]
+    private string $intensity = 'moderate';
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getScheduledAt(): ?\DateTimeImmutable
+    {
+        return $this->scheduledAt;
+    }
+
+    public function setScheduledAt(\DateTimeImmutable $scheduledAt): self
+    {
+        $this->scheduledAt = $scheduledAt;
+        return $this;
+    }
+
+    public function getDurationMinutes(): int
+    {
+        return $this->durationMinutes;
+    }
+
+    public function setDurationMinutes(int $durationMinutes): self
+    {
+        $this->durationMinutes = $durationMinutes;
+        return $this;
+    }
+
+    public function getExercises(): array
+    {
+        return $this->exercises;
+    }
+
+    public function setExercises(array $exercises): self
+    {
+        $this->exercises = $exercises;
+        return $this;
+    }
+
+    public function getProgram(): ?TrainingProgram
+    {
+        return $this->program;
+    }
+
+    public function setProgram(?TrainingProgram $program): self
+    {
+        $this->program = $program;
+        return $this;
+    }
+
+    public function getIntensity(): string
+    {
+        return $this->intensity;
+    }
+
+    public function setIntensity(string $intensity): self
+    {
+        $this->intensity = $intensity;
+        return $this;
+    }
+}

--- a/backend/src/Entity/User.php
+++ b/backend/src/Entity/User.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace App\Entity;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Delete;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'app_user')]
+#[ApiResource(
+    operations: [
+        new Get(security: "is_granted('ROLE_ADMIN') or object == user"),
+        new GetCollection(security: "is_granted('ROLE_ADMIN')"),
+        new Post(denormalizationContext: ['groups' => ['user:write']], security: "is_granted('ROLE_ADMIN')"),
+        new Patch(security: "is_granted('ROLE_ADMIN') or object == user"),
+        new Delete(security: "is_granted('ROLE_ADMIN')")
+    ],
+    normalizationContext: ['groups' => ['user:read']],
+    denormalizationContext: ['groups' => ['user:write']]
+)]
+class User implements UserInterface, PasswordAuthenticatedUserInterface
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    #[Groups(['user:read', 'program:read'])]
+    private ?int $id = null;
+
+    #[ORM\Column(type: 'string', length: 180, unique: true)]
+    #[Assert\Email]
+    #[Groups(['user:read', 'user:write'])]
+    private string $email = '';
+
+    #[ORM\Column(type: 'json')]
+    #[Groups(['user:read', 'user:write'])]
+    private array $roles = ['ROLE_USER'];
+
+    #[ORM\Column(type: 'string')]
+    #[Groups(['user:write'])]
+    private string $password = '';
+
+    #[ORM\OneToMany(mappedBy: 'owner', targetEntity: TrainingProgram::class, cascade: ['persist'], orphanRemoval: true)]
+    #[Groups(['user:read'])]
+    private Collection $programs;
+
+    public function __construct()
+    {
+        $this->programs = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    public function setEmail(string $email): self
+    {
+        $this->email = $email;
+        return $this;
+    }
+
+    public function getUserIdentifier(): string
+    {
+        return $this->email;
+    }
+
+    public function getRoles(): array
+    {
+        return array_unique(array_merge($this->roles, ['ROLE_USER']));
+    }
+
+    public function setRoles(array $roles): self
+    {
+        $this->roles = $roles;
+        return $this;
+    }
+
+    public function getPassword(): string
+    {
+        return $this->password;
+    }
+
+    public function setPassword(string $password): self
+    {
+        $this->password = $password;
+        return $this;
+    }
+
+    public function eraseCredentials(): void
+    {
+    }
+
+    /**
+     * @return Collection<int, TrainingProgram>
+     */
+    public function getPrograms(): Collection
+    {
+        return $this->programs;
+    }
+
+    public function addProgram(TrainingProgram $program): self
+    {
+        if (!$this->programs->contains($program)) {
+            $this->programs[] = $program;
+            $program->setOwner($this);
+        }
+
+        return $this;
+    }
+
+    public function removeProgram(TrainingProgram $program): self
+    {
+        if ($this->programs->removeElement($program) && $program->getOwner() === $this) {
+            $program->setOwner(null);
+        }
+
+        return $this;
+    }
+}

--- a/backend/src/Kernel.php
+++ b/backend/src/Kernel.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App;
+
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\HttpKernel\Kernel as BaseKernel;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+
+class Kernel extends BaseKernel
+{
+    use MicroKernelTrait;
+
+    protected function configureContainer(ContainerConfigurator $container): void
+    {
+        $container->import('../config/{packages}/*.yaml');
+        $container->import('../config/{packages}/'.$this->environment.'/*.yaml');
+
+        if (is_file(dirname(__DIR__).'/config/services.yaml')) {
+            $container->import('../config/services.yaml');
+
+            $envServiceFile = dirname(__DIR__).'/config/services_'.$this->environment.'.yaml';
+            if (is_file($envServiceFile)) {
+                $container->import('../config/services_'.$this->environment.'.yaml');
+            }
+        } elseif (is_file(dirname(__DIR__).'/config/services.php')) {
+            $container->import('../config/services.php');
+        }
+    }
+
+    protected function configureRoutes(RoutingConfigurator $routes): void
+    {
+        $routes->import('../config/{routes}/'.$this->environment.'/*.yaml');
+        $routes->import('../config/{routes}/*.yaml');
+
+        if (is_file(dirname(__DIR__).'/config/routes.yaml')) {
+            $routes->import('../config/routes.yaml');
+        } elseif (is_file(dirname(__DIR__).'/config/routes.php')) {
+            $routes->import('../config/routes.php');
+        }
+    }
+}

--- a/backend/tests/ProgramApiTest.php
+++ b/backend/tests/ProgramApiTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Tests;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Entity\TrainingProgram;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+
+class ProgramApiTest extends ApiTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        $schemaTool = new SchemaTool($entityManager);
+        $metadata = $entityManager->getMetadataFactory()->getAllMetadata();
+        $schemaTool->dropDatabase();
+        $schemaTool->createSchema($metadata);
+    }
+
+    public function testCollectionIsPaginated(): void
+    {
+        static::createClient()->request('GET', '/training_programs');
+        self::assertResponseStatusCodeSame(200);
+        self::assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        self::assertMatchesResourceCollectionJsonSchema(TrainingProgram::class);
+    }
+}

--- a/backend/tests/bootstrap.php
+++ b/backend/tests/bootstrap.php
@@ -1,0 +1,9 @@
+<?php
+
+use Symfony\Component\Dotenv\Dotenv;
+
+require dirname(__DIR__).'/vendor/autoload.php';
+
+if (method_exists(Dotenv::class, 'bootEnv')) {
+    (new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
+}

--- a/backend/var/.gitignore
+++ b/backend/var/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/docs/fullstack-skeleton.md
+++ b/docs/fullstack-skeleton.md
@@ -1,0 +1,70 @@
+# MuscleMind API Platform + React Skeleton
+
+Ce document décrit comment les dossiers `backend/` et `frontend/` interagissent pour fournir une application complète.
+
+## Flux d'authentification
+
+1. L'utilisateur saisit ses identifiants dans la page React `/login`.
+2. `loginRequest` appelle `POST http://localhost:8000/auth/login` (géré par Symfony Security + Lexik JWT).
+3. Le token reçu est stocké via `AuthContext` et ajouté dans les en-têtes Axios.
+4. Les requêtes vers `/training_programs` et `/training_sessions` sont protégées par `security.yaml`.
+
+## Exemple de requête
+
+### Création d'un programme
+
+```
+POST /training_programs
+Authorization: Bearer <JWT>
+Content-Type: application/json
+
+{
+  "name": "Hypertrophie 6 semaines",
+  "description": "Push/Pull/Legs",
+  "isPublished": true
+}
+```
+
+### Réponse JSON-LD
+
+```
+HTTP/1.1 201 Created
+Content-Type: application/ld+json
+
+{
+  "@context": "/contexts/TrainingProgram",
+  "@id": "/training_programs/1",
+  "@type": "TrainingProgram",
+  "name": "Hypertrophie 6 semaines",
+  "description": "Push/Pull/Legs",
+  "isPublished": true,
+  "sessions": []
+}
+```
+
+## Ajouter une nouvelle fonctionnalité
+
+1. Décrire le besoin dans `docs/`.
+2. Créer entité + tests côté backend.
+3. Exposer la ressource via API Platform.
+4. Ajouter un service React Query + composant UI.
+5. Documenter les routes dans Swagger (`/docs`) et dans le README frontend.
+
+## Démarrage rapide (local)
+
+```bash
+# Backend API Platform
+cd backend
+composer install
+php bin/console doctrine:database:create --if-not-exists
+php bin/console doctrine:migrations:migrate
+php bin/console lexik:jwt:generate-keypair --overwrite
+symfony server:start -d --dir=public
+
+# Frontend React
+cd ../frontend
+npm install
+npm run dev
+```
+
+Les tests automatisés peuvent s'exécuter sans MySQL grâce à SQLite (`php bin/phpunit` côté backend, `npm run test` côté frontend).

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,41 @@
+# MuscleMind React Frontend
+
+Interface utilisateur construite avec React 18, Vite et Material UI.
+
+## Installation
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+Le serveur Vite écoute sur `http://localhost:5173` et proxifie les appels `/api` vers le backend Symfony.
+
+## Architecture
+
+- `src/pages` : vues (connexion, programmes, sessions)
+- `src/components` : composants réutilisables (`ResourceList`, `ResourceForm`)
+- `src/context` : contexte global pour l'authentification
+- `src/services` : client HTTP Axios + fonctions métiers
+- `src/styles.scss` : styles globaux
+
+## Authentification
+
+- Le token JWT est stocké dans `localStorage` via `AuthContext`.
+- Le hook `useAuth` expose `login`, `logout`, `token` et `isAuthenticated`.
+- Les routes protégées utilisent `PrivateRoute` dans `App.jsx`.
+
+## Appels API
+
+Les données sont chargées avec React Query (`useQuery`, `useMutation`). Les états de chargement/erreur sont affichés via Material UI.
+
+## Tests
+
+Un setup Vitest + React Testing Library est configuré via la commande :
+
+```bash
+npm run test
+```
+
+Ajoutez vos tests dans `src/components/__tests__` ou `src/pages/__tests__` selon les cas d'utilisation.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "musclemind-react-frontend",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@mui/material": "^5.15.15",
+    "@tanstack/react-query": "^5.51.9",
+    "axios": "^1.6.8",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.22.3"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.2.2",
+    "@testing-library/user-event": "^14.5.2",
+    "@vitejs/plugin-react": "^4.2.1",
+    "jsdom": "^24.0.0",
+    "sass": "^1.72.0",
+    "vite": "^5.2.0",
+    "vitest": "^1.4.0"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MuscleMind React</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,38 @@
+import { Routes, Route, Navigate } from 'react-router-dom';
+import Container from '@mui/material/Container';
+import LoginPage from './pages/LoginPage.jsx';
+import ProgramsPage from './pages/ProgramsPage.jsx';
+import SessionsPage from './pages/SessionsPage.jsx';
+import { useAuth } from './context/AuthContext.jsx';
+
+const PrivateRoute = ({ children }) => {
+  const { isAuthenticated } = useAuth();
+  return isAuthenticated ? children : <Navigate to="/login" replace />;
+};
+
+export default function App() {
+  return (
+    <Container maxWidth="lg">
+      <Routes>
+        <Route path="/login" element={<LoginPage />} />
+        <Route
+          path="/programs"
+          element={
+            <PrivateRoute>
+              <ProgramsPage />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/sessions/:programId"
+          element={
+            <PrivateRoute>
+              <SessionsPage />
+            </PrivateRoute>
+          }
+        />
+        <Route path="*" element={<Navigate to="/programs" replace />} />
+      </Routes>
+    </Container>
+  );
+}

--- a/frontend/src/components/ResourceForm.jsx
+++ b/frontend/src/components/ResourceForm.jsx
@@ -1,0 +1,49 @@
+import PropTypes from 'prop-types';
+import { useState } from 'react';
+import { Stack, TextField, Button } from '@mui/material';
+
+export default function ResourceForm({ onSubmit, initialValues = { name: '', description: '' }, ctaLabel }) {
+  const [values, setValues] = useState(initialValues);
+
+  const handleChange = (event) => {
+    setValues({ ...values, [event.target.name]: event.target.value });
+  };
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    onSubmit(values);
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <Stack spacing={2}>
+        <TextField name="name" label="Nom" value={values.name} onChange={handleChange} required />
+        <TextField
+          name="description"
+          label="Description"
+          value={values.description}
+          onChange={handleChange}
+          multiline
+          rows={3}
+        />
+        <Button type="submit" variant="contained">
+          {ctaLabel}
+        </Button>
+      </Stack>
+    </form>
+  );
+}
+
+ResourceForm.propTypes = {
+  onSubmit: PropTypes.func.isRequired,
+  initialValues: PropTypes.shape({
+    name: PropTypes.string,
+    description: PropTypes.string
+  }),
+  ctaLabel: PropTypes.string
+};
+
+ResourceForm.defaultProps = {
+  initialValues: { name: '', description: '' },
+  ctaLabel: 'Enregistrer'
+};

--- a/frontend/src/components/ResourceList.jsx
+++ b/frontend/src/components/ResourceList.jsx
@@ -1,0 +1,33 @@
+import PropTypes from 'prop-types';
+import { List, ListItem, ListItemText, CircularProgress, Alert } from '@mui/material';
+
+export default function ResourceList({ items, isLoading, isError, emptyLabel, onSelect }) {
+  if (isLoading) return <CircularProgress data-testid="loader" />;
+  if (isError) return <Alert severity="error">Impossible de charger les données.</Alert>;
+  if (!items.length) return <Alert severity="info">{emptyLabel}</Alert>;
+
+  return (
+    <List>
+      {items.map((item) => (
+        <ListItem key={item['@id'] ?? item.id} button onClick={() => onSelect?.(item)}>
+          <ListItemText primary={item.name} secondary={item.description} />
+        </ListItem>
+      ))}
+    </List>
+  );
+}
+
+ResourceList.propTypes = {
+  items: PropTypes.arrayOf(PropTypes.object).isRequired,
+  isLoading: PropTypes.bool,
+  isError: PropTypes.bool,
+  emptyLabel: PropTypes.string,
+  onSelect: PropTypes.func
+};
+
+ResourceList.defaultProps = {
+  isLoading: false,
+  isError: false,
+  emptyLabel: 'Aucune ressource disponible',
+  onSelect: undefined
+};

--- a/frontend/src/components/__tests__/ResourceList.test.jsx
+++ b/frontend/src/components/__tests__/ResourceList.test.jsx
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ResourceList from '../ResourceList.jsx';
+
+describe('ResourceList', () => {
+  it('affiche un message lorsque la liste est vide', () => {
+    render(<ResourceList items={[]} emptyLabel="Aucun élément" />);
+    expect(screen.getByText('Aucun élément')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,0 +1,31 @@
+import { createContext, useContext, useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+
+const AuthContext = createContext();
+
+export const AuthProvider = ({ children }) => {
+  const [token, setToken] = useState(() => localStorage.getItem('token'));
+
+  useEffect(() => {
+    if (token) {
+      localStorage.setItem('token', token);
+    } else {
+      localStorage.removeItem('token');
+    }
+  }, [token]);
+
+  const login = (jwt) => setToken(jwt);
+  const logout = () => setToken(null);
+
+  return (
+    <AuthContext.Provider value={{ token, login, logout, isAuthenticated: Boolean(token) }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+AuthProvider.propTypes = {
+  children: PropTypes.node.isRequired
+};
+
+export const useAuth = () => useContext(AuthContext);

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import App from './App.jsx';
+import { AuthProvider } from './context/AuthContext.jsx';
+import './styles.scss';
+
+const queryClient = new QueryClient();
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <AuthProvider>
+          <App />
+        </AuthProvider>
+      </BrowserRouter>
+    </QueryClientProvider>
+  </React.StrictMode>
+);

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Paper, Stack, TextField, Button, Typography } from '@mui/material';
+import { useAuth } from '../context/AuthContext.jsx';
+import { loginRequest } from '../services/apiClient.js';
+
+export default function LoginPage() {
+  const [credentials, setCredentials] = useState({ email: '', password: '' });
+  const [error, setError] = useState(null);
+  const navigate = useNavigate();
+  const { login } = useAuth();
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    try {
+      const token = await loginRequest(credentials);
+      login(token);
+      navigate('/programs');
+    } catch (err) {
+      setError('Identifiants invalides.');
+    }
+  };
+
+  return (
+    <Paper elevation={3} sx={{ padding: 4, marginTop: 8 }}>
+      <Typography variant="h5" mb={2}>
+        Connexion
+      </Typography>
+      <form onSubmit={handleSubmit}>
+        <Stack spacing={2}>
+          <TextField
+            label="Email"
+            type="email"
+            value={credentials.email}
+            onChange={(event) => setCredentials({ ...credentials, email: event.target.value })}
+            required
+          />
+          <TextField
+            label="Mot de passe"
+            type="password"
+            value={credentials.password}
+            onChange={(event) => setCredentials({ ...credentials, password: event.target.value })}
+            required
+          />
+          {error && (
+            <Typography color="error" role="alert">
+              {error}
+            </Typography>
+          )}
+          <Button type="submit" variant="contained">
+            Se connecter
+          </Button>
+        </Stack>
+      </form>
+    </Paper>
+  );
+}

--- a/frontend/src/pages/ProgramsPage.jsx
+++ b/frontend/src/pages/ProgramsPage.jsx
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+import { Typography, Grid, Paper } from '@mui/material';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useAuth } from '../context/AuthContext.jsx';
+import { apiClient } from '../services/apiClient.js';
+import ResourceList from '../components/ResourceList.jsx';
+import ResourceForm from '../components/ResourceForm.jsx';
+
+export default function ProgramsPage() {
+  const { token } = useAuth();
+  const [selectedProgram, setSelectedProgram] = useState(null);
+  const queryClient = useQueryClient();
+  const client = apiClient(token);
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['programs'],
+    queryFn: async () => {
+      const { data: response } = await client.get('/training_programs');
+      return response['hydra:member'] ?? [];
+    }
+  });
+
+  const mutation = useMutation({
+    mutationFn: async (payload) => client.post('/training_programs', payload),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['programs'] })
+  });
+
+  return (
+    <Grid container spacing={4} mt={4}>
+      <Grid item xs={12} md={6}>
+        <Paper sx={{ padding: 3 }}>
+          <Typography variant="h6" mb={2}>
+            Programmes
+          </Typography>
+          <ResourceList
+            items={data ?? []}
+            isLoading={isLoading}
+            isError={isError}
+            emptyLabel="Aucun programme publié"
+            onSelect={setSelectedProgram}
+          />
+        </Paper>
+      </Grid>
+      <Grid item xs={12} md={6}>
+        <Paper sx={{ padding: 3 }}>
+          <Typography variant="h6" mb={2}>
+            Créer un programme
+          </Typography>
+          <ResourceForm
+            ctaLabel="Publier"
+            onSubmit={(payload) => mutation.mutate({ ...payload, isPublished: true })}
+          />
+          {selectedProgram && (
+            <Typography mt={3}>
+              Dernier programme sélectionné : <strong>{selectedProgram.name}</strong>
+            </Typography>
+          )}
+        </Paper>
+      </Grid>
+    </Grid>
+  );
+}

--- a/frontend/src/pages/SessionsPage.jsx
+++ b/frontend/src/pages/SessionsPage.jsx
@@ -1,0 +1,43 @@
+import { useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { Typography, Paper, List, ListItem, ListItemText } from '@mui/material';
+import { useAuth } from '../context/AuthContext.jsx';
+import { apiClient } from '../services/apiClient.js';
+
+export default function SessionsPage() {
+  const { programId } = useParams();
+  const { token } = useAuth();
+  const client = apiClient(token);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['sessions', programId],
+    queryFn: async () => {
+      const { data: response } = await client.get('/training_sessions', {
+        params: { 'program.id': programId }
+      });
+      return response['hydra:member'] ?? [];
+    }
+  });
+
+  return (
+    <Paper sx={{ padding: 3, marginTop: 4 }}>
+      <Typography variant="h5" mb={2}>
+        Sessions du programme #{programId}
+      </Typography>
+      {isLoading ? (
+        <Typography>Chargement...</Typography>
+      ) : (
+        <List>
+          {data.map((session) => (
+            <ListItem key={session['@id'] ?? session.id}>
+              <ListItemText
+                primary={`Séance du ${new Date(session.scheduledAt).toLocaleDateString('fr-FR')}`}
+                secondary={`${session.durationMinutes} min - Intensité: ${session.intensity}`}
+              />
+            </ListItem>
+          ))}
+        </List>
+      )}
+    </Paper>
+  );
+}

--- a/frontend/src/services/apiClient.js
+++ b/frontend/src/services/apiClient.js
@@ -1,0 +1,15 @@
+import axios from 'axios';
+
+export const apiClient = (token) =>
+  axios.create({
+    baseURL: 'http://localhost:8000',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {})
+    }
+  });
+
+export const loginRequest = async ({ email, password }) => {
+  const { data } = await axios.post('http://localhost:8000/auth/login', { email, password });
+  return data.token;
+};

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -1,0 +1,15 @@
+body {
+  margin: 0;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #0f172a;
+  color: #f8fafc;
+}
+
+#root {
+  min-height: 100vh;
+  padding: 2rem 0;
+}
+
+a {
+  color: #38bdf8;
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8000',
+        changeOrigin: true
+      }
+    }
+  }
+});

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: './vitest.setup.js'
+  }
+});

--- a/frontend/vitest.setup.js
+++ b/frontend/vitest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,11 @@
 - **Charts** : Chart.js 4.4 avec plugins avancés
 - **Build Tools** : Webpack Encore
 
+### Nouveau squelette full-stack
+- **API Platform** : voir `backend/` pour un exemple prêt à l'emploi avec JWT, pagination, filtres et une structure Symfony complète (`bin/console`, `public/index.php`, tests ApiTestCase).
+- **React + Vite** : voir `frontend/` pour l'UI moderne (Material UI, React Query, routing).
+- **Documentation** : les flux API/Front sont décrits dans `docs/fullstack-skeleton.md` (avec un guide de démarrage).
+
 ### DevOps & Outils
 - **Bundler** : Composer (PHP) + NPM (JavaScript)
 - **Migration** : Doctrine Migrations


### PR DESCRIPTION
## Summary
- add the missing Symfony runtime files (bin/console, public/index.php, Kernel) and configuration so the API Platform backend can actually run commands and serve HTTP traffic
- extend the backend dependencies and ApiTestCase bootstrap so Doctrine schemas are created automatically and resource security (e.g. session creation) is enforced correctly
- document the new workflow across backend/README.md, docs/fullstack-skeleton.md, and the main README to highlight how to start the stack

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c9d5fd9888321919a1a6eda721ad9)